### PR TITLE
Fix builder Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11-alpine AS builder
+FROM golang:1.12-alpine AS builder
 
 RUN apk add --update git ca-certificates && update-ca-certificates
 


### PR DESCRIPTION
This PR will remove incompatibility between go.mod and Dockerfile of Go version. 

Currently at master branch:
- go.mod file has 1.12

https://github.com/kakkoyun/simple-web-server/blob/b5a585aa5341c85ec67b5541d9f16f4591d63be8/go.mod#L3

- Builder at Dockerfile has 1.11

https://github.com/kakkoyun/simple-web-server/blob/b5a585aa5341c85ec67b5541d9f16f4591d63be8/Dockerfile#L1

After the merge, you will have 1.12 at both places 🎉 